### PR TITLE
Static man page (#14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -336,16 +336,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "clap_mangen"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07"
-dependencies = [
- "clap",
- "roff",
-]
 
 [[package]]
 name = "color-eyre"
@@ -843,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linked-hash-map"
@@ -867,9 +857,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "math-core"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b8fdec2f8a29eeceb845d4b20e3af42bc765100dbb01dfafae2079a81d0fb"
+checksum = "938914f21d07488e5c9b2386d951494976b158b9616ee67bbda5afa5c2924eeb"
 dependencies = [
  "math-core-renderer-internal",
  "memchr",
@@ -882,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "math-core-renderer-internal"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4453b8a04db2fbc444c960d069ecd8d7b9be930e88f63a7a6558dee1965db709"
+checksum = "3716dfbc3e092d5b212c0b03e6fedb60ffbceb21ed5df9346a09866f47d07e84"
 dependencies = [
  "bitflags 2.11.1",
  "dtoa",
@@ -907,7 +897,6 @@ dependencies = [
  "askama",
  "axum",
  "clap",
- "clap_mangen",
  "color-eyre",
  "comrak",
  "futures",
@@ -1041,9 +1030,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
-version = "6.5.1"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -1053,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.9.1"
+version = "69.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1157,9 +1146,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64",
  "indexmap",
@@ -1195,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
@@ -1227,12 +1216,6 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "roff"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rust-embed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ authors = ["Samuel Åkesson <sermuns@lysator.liu.se>"]
 askama = { version = "0.15", default-features = false, features = ["std", "derive"] }
 axum = { version = "0.8", default-features = false, features = ["tokio", "http1"] }
 clap = { version = "4", features = ["derive"] }
-clap_mangen = "0.3"
 color-eyre = { version = "0.6", default-features = false, features = ["track-caller"] }
 comrak = { version = "0.52", default-features = false, features = ["bon", "shortcodes", "syntect"] }
 futures = { version = "0.3", default-features = false }

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Options:
   -a, --address <ADDRESS>        Address to bind the server to [default: localhost:3000]
   -o, --open                     Whether to open the browser on serve
   -l, --light-mode               Render page in light-mode style
-      --generate-manpage         Print manpage to stdout and exit
   -h, --help                     Print help
   -V, --version                  Print version
 ```
@@ -138,6 +137,10 @@ Can be installed by
 
 ```bash
 mkdir -p ~/.local/share/man/man1/
-meread --generate-manpage > ~/.local/share/man/man1/meread.1
-```
+# if downloaded from source using `git clone`:
+cp ./meread.1 ~/.local/share/man/man1/meread.1
 
+# otherwise:
+curl -fsSL -o ~/.local/share/man/man1/meread.1 \
+  "https://raw.githubusercontent.com/sermuns/MEREAD/main/meread.1"
+```

--- a/meread.1
+++ b/meread.1
@@ -1,0 +1,39 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH meread 1 "meread 0.7.0"
+.SH NAME
+meread \- preview github flavored markdown locally
+.SH SYNOPSIS
+\fBmeread\fR [\fB\-e\fR|\fB\-\-export\-dir\fR] [\fB\-f\fR|\fB\-\-force\fR] [\fB\-a\fR|\fB\-\-address\fR] [\fB\-o\fR|\fB\-\-open\fR] [\fB\-l\fR|\fB\-\-light\-mode\fR] [\fB\-\-generate\-manpage\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIPATH\fR] 
+.SH DESCRIPTION
+preview github flavored markdown locally
+.SH OPTIONS
+.TP
+\fB\-e\fR, \fB\-\-export\-dir\fR \fI<EXPORT_DIR>\fR
+If supplied, will export the markdown file to HTML in the specified directory
+.TP
+\fB\-f\fR, \fB\-\-force\fR
+Whether to overwrite the export directory if it exists
+.TP
+\fB\-a\fR, \fB\-\-address\fR \fI<ADDRESS>\fR [default: localhost:3000]
+Address to bind the server to
+.TP
+\fB\-o\fR, \fB\-\-open\fR
+Whether to open the browser on serve
+.TP
+\fB\-l\fR, \fB\-\-light\-mode\fR
+Render page in light\-mode style
+.TP
+\fB\-\-generate\-manpage\fR
+Print manpage to stdout and exit
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version
+.TP
+[\fIPATH\fR] [default: .]
+Path to markdown file or directory containing README.md
+.SH VERSION
+v0.7.0

--- a/meread.1
+++ b/meread.1
@@ -1,36 +1,50 @@
-.ie \n(.g .ds Aq \(aq
-.el .ds Aq '
-.TH meread 1 "meread 0.7.0"
+.TH MEREAD 1 ""
 .SH NAME
-meread \- preview github flavored markdown locally
+\fBmeread\fR \- preview github flavored markdown locally
+.
 .SH SYNOPSIS
-\fBmeread\fR [\fB\-e\fR|\fB\-\-export\-dir\fR] [\fB\-f\fR|\fB\-\-force\fR] [\fB\-a\fR|\fB\-\-address\fR] [\fB\-o\fR|\fB\-\-open\fR] [\fB\-l\fR|\fB\-\-light\-mode\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIPATH\fR]
+.B meread
+.RB [ \-e | \-\-export\-dir
+.IR directory ]
+.RB [ \-f | \-\-force ]
+.RB [ \-a | \-\-address
+.IR address ]
+.RB [ \-o | \-\-open ]
+.RB [ \-l | \-\-light\-mode ]
+.RB [ \-h | \-\-help ]
+.RB [ \-V | \-\-version ]
+.RI [ path ]
+.
 .SH DESCRIPTION
-preview github flavored markdown locally
+\fBmeread\fR is a command\-line tool for previewing Markdown files as they
+will be presented on GitHub, all completely locally and offline.
+.
 .SH OPTIONS
 .TP
-\fB\-e\fR, \fB\-\-export\-dir\fR \fI<EXPORT_DIR>\fR
-If supplied, will export the markdown file to HTML in the specified directory
+.I path
+Path to markdown file or directory containing README.md [default: \fB.\fR].
 .TP
-\fB\-f\fR, \fB\-\-force\fR
-Whether to overwrite the export directory if it exists
+.BR \-e ", " \-\-export\-dir " \fIdirectory\fR"
+If supplied, will export the markdown file to HTML in the specified directory.
 .TP
-\fB\-a\fR, \fB\-\-address\fR \fI<ADDRESS>\fR [default: localhost:3000]
-Address to bind the server to
+.BR \-f ", " \-\-force
+Whether to overwrite the export directory if it exists.
 .TP
-\fB\-o\fR, \fB\-\-open\fR
-Whether to open the browser on serve
+.BR \-a ", " \-\-address " \fIaddress\fR"
+The address to bind the server to [default: \fBlocalhost:3000\fR].
 .TP
-\fB\-l\fR, \fB\-\-light\-mode\fR
-Render page in light\-mode style
+.BR \-o ", " \-\-open
+Whether to open the browser on serve.
 .TP
-\fB\-h\fR, \fB\-\-help\fR
-Print help
+.BR \-l ", " \-\-light\-mode
+Render page in light\-mode style.
 .TP
-\fB\-V\fR, \fB\-\-version\fR
-Print version
+.BR \-h ", " \-\-help
+Print help.
 .TP
-[\fIPATH\fR] [default: .]
-Path to markdown file or directory containing README.md
-.SH VERSION
-v0.7.0
+.BR \-V ", " \-\-version
+Print version.
+.
+.SH BUGS
+Bugs can be reported on GitHub:
+.I https://github.com/sermuns/MEREAD/issues

--- a/meread.1
+++ b/meread.1
@@ -4,7 +4,7 @@
 .SH NAME
 meread \- preview github flavored markdown locally
 .SH SYNOPSIS
-\fBmeread\fR [\fB\-e\fR|\fB\-\-export\-dir\fR] [\fB\-f\fR|\fB\-\-force\fR] [\fB\-a\fR|\fB\-\-address\fR] [\fB\-o\fR|\fB\-\-open\fR] [\fB\-l\fR|\fB\-\-light\-mode\fR] [\fB\-\-generate\-manpage\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIPATH\fR] 
+\fBmeread\fR [\fB\-e\fR|\fB\-\-export\-dir\fR] [\fB\-f\fR|\fB\-\-force\fR] [\fB\-a\fR|\fB\-\-address\fR] [\fB\-o\fR|\fB\-\-open\fR] [\fB\-l\fR|\fB\-\-light\-mode\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIPATH\fR]
 .SH DESCRIPTION
 preview github flavored markdown locally
 .SH OPTIONS
@@ -23,9 +23,6 @@ Whether to open the browser on serve
 .TP
 \fB\-l\fR, \fB\-\-light\-mode\fR
 Render page in light\-mode style
-.TP
-\fB\-\-generate\-manpage\fR
-Print manpage to stdout and exit
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/package.nix
+++ b/package.nix
@@ -13,6 +13,13 @@ in
 
     src = ./.;
 
+    # for installManPage
+    nativeBuildInputs = [pkgs.installShellFiles];
+
+    postInstall = ''
+      installManPage ./meread.1
+    '';
+
     meta = {
       inherit (toml) description license;
       homepage = toml.repository;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use axum::{
     response::{Html, IntoResponse},
     routing::get,
 };
-use clap::{CommandFactory, Parser};
+use clap::Parser;
 use color_eyre::{
     Result,
     eyre::{Context, ContextCompat},
@@ -59,10 +59,6 @@ struct Args {
     /// Render page in light-mode style
     #[arg(long, short)]
     light_mode: bool,
-
-    /// Print manpage to stdout and exit
-    #[arg(long)]
-    generate_manpage: bool,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -73,12 +69,6 @@ async fn main() -> Result<()> {
         .install()?;
 
     let args = Args::parse();
-
-    if args.generate_manpage {
-        let cmd = Args::command();
-        clap_mangen::Man::new(cmd).render(&mut std::io::stdout())?;
-        return Ok(());
-    }
 
     let markdown_file_path = if args.path.is_dir() {
         args.path.join("README.md")


### PR DESCRIPTION
Closes #14.

Start with the man page generated by clap_mangen:
```sh
cargo run -q -- --generate-manpage > meread.1
```
... then improve upon it. Also, update README.md and nix instructions.

Resources:
* (g)roff language reference:
    * <https://man7.org/linux/man-pages/man7/groff.7.html>
    * <https://man7.org/linux/man-pages/man7/groff_man.7.html>
* conventions for writing Linux man pages: <https://man7.org/linux/man-pages/man7/man-pages.7.html>